### PR TITLE
Fixed a typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The API works with [Adia_TTS](https://huggingface.co/CONCREE/Adia_TTS) model and
 
 1. Clone this repository:
    ```bash
-   git clone https://github.com/sudoping01/adia-tts-inference-server/
+   git clone https://github.com/sudoping01/adia-inference-server/
 
    cd adia-tts-inference-server
    ```


### PR DESCRIPTION
Fixed a typo on the repository url when using git clone command from README.md. Changed from part of link "adia-tts-inference-server" to "adia-inference-server" to make it work correctly.